### PR TITLE
Bitstream file support

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,1 +1,1 @@
-from tinyfpgaa import *
+from .tinyfpgaa import *

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,1 @@
+from tinyfpgaa import *

--- a/python/tinyfpgaa.py
+++ b/python/tinyfpgaa.py
@@ -1108,6 +1108,108 @@ class JedecFile(object):
 
 
 
+class BitstreamFile(object):
+    def __init__(self, bit_file):
+        self.cfg_data = None
+        self.ebr_data = None
+        self.ufm_data = None
+        self.feature_row = None
+        self.feature_bits = None
+        self.last_note = ""
+        self._parse(bit_file)
+
+    def numRows(self):
+        def toInt(list_or_none):
+            if list_or_none is None:
+                return 0
+            else:
+                return len(list_or_none)
+
+        return toInt(self.cfg_data) + toInt(self.ebr_data) + toInt(self.ufm_data)
+
+    def _parse(self, bit):
+        def bytestring_reverse_to_int(bytestr):
+            rev_line = []
+            for l in reversed(bytestr):
+                b = bin(l)
+                b_rev = b[-1:1:-1]
+                b_rev = b_rev + (8 - len(b_rev))*'0'
+                rev_line.append(int(b_rev, 2))
+
+            return int.from_bytes(rev_line, byteorder='big')
+
+        def line_to_int(line):
+            try:
+                return int(line[::-1], 16)
+            except:
+                traceback.print_exc()
+                return None
+
+        # Validate we have a bitstream.
+        if bit.read(2) != b"\xff\x00":
+            raise ValueError("Bitstream file does not begin with 0xFF00.")
+
+        while True:
+            val = bit.read(1)
+            if bit.peek(4)[:4] == b"\xff\xff\xbd\xb3":
+                break
+            if not val:
+                raise ValueError("Could not find bitstream preamble.")
+
+        start_of_data = bit.tell()
+
+        # Eat characters and commands until we find a compressed bitstream.
+        bit.read(4)
+        while True:
+            cmd = bit.read(1)
+
+            # BYPASS
+            if cmd == b"\xff":
+                pass
+            # LSC_RESET_CRC
+            elif cmd == b"\x3b":
+                bit.read(3)
+            # VERIFY_ID
+            elif cmd == b"\xe2":
+                bit.read(7)
+            # LSC_WRITE_COMP_DIC
+            elif cmd == b"\x02":
+                bit.read(11)
+            # LSC_PROG_CNTRL0
+            elif cmd == b"\x22":
+                bit.read(7)
+            # LSC_INIT_ADDRESS
+            elif cmd == b"\x46":
+                bit.read(3)
+            # LSC_PROG_INCR_CMP
+            elif cmd == b"\xb8":
+                break
+            # LSC_PROG_INCR_RTI
+            elif cmd == b"\x82":
+                raise ValueError("Bitstream is not compressed- not writing.")
+            else:
+                assert False, "Unknown command type {}.".format(cmd)
+
+        bit.seek(start_of_data)
+
+        data = []
+        done = False
+        while not done:
+            line = bit.read(16)
+
+            if len(line) < 16:
+                line = line + b"\xff" * (16 - len(line))
+                done = True
+
+            data.append(bytestring_reverse_to_int(line))
+
+        self.cfg_data = data
+        self.feature_row = 0
+        self.feature_bits = int("0000010001100000", 2)
+
+
+
+
 class JtagCustomProgrammer(object):
     def __init__(self, jtag):
         self.jtag = jtag

--- a/python/tinyproga.py
+++ b/python/tinyproga.py
@@ -1,0 +1,48 @@
+import sys
+import traceback
+import argparse
+import serial
+from serial.tools.list_ports import comports
+import tinyfpgaa
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-q", action="store_true", help="Silent mode.")
+    parser.add_argument("-p", type=str, help="Manually specify serial device.")
+    parser.add_argument("jed", type=str, help="JEDEC file to program.")
+    args = parser.parse_args()
+
+    if not args.p:
+        for port in comports():
+            if "1209:2101" in port[2]:
+                a_port = port[0]
+                break
+        else:
+            print("TinyFPGA A not detected! Is it plugged in?")
+            sys.exit(1)
+    else:
+        a_port = args.p
+
+    with serial.Serial(a_port, 12000000, timeout=10, writeTimeout=5) as ser:
+        async_serial = tinyfpgaa.SyncSerial(ser)
+        pins = tinyfpgaa.JtagTinyFpgaProgrammer(async_serial)
+        jtag = tinyfpgaa.Jtag(pins)
+        programmer = tinyfpgaa.JtagCustomProgrammer(jtag)
+
+        if not args.q:
+            print("Parsing JEDEC file...")
+        jedec_file = tinyfpgaa.JedecFile(open(args.jed, 'r'))
+
+        try:
+            if not args.q:
+                print("Programming TinyFPGA A on {}...".format(a_port))
+            programmer.program(jedec_file)
+        except:
+            print("Programming Failed!")
+            traceback.print_exc()
+            sys.exit(2)
+
+    print("Programming finished without error.")
+
+if __name__ == "__main__":
+    main()

--- a/python/tinyproga.py
+++ b/python/tinyproga.py
@@ -9,7 +9,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-q", action="store_true", help="Silent mode.")
     parser.add_argument("-p", type=str, help="Manually specify serial device.")
-    parser.add_argument("jed", type=str, help="JEDEC file to program.")
+    parser.add_argument("-b", action="store_true", help="Input is bitstream file.")
+    parser.add_argument("jed", type=str, help="JEDEC or bitstream file to program.")
     args = parser.parse_args()
 
     if not args.p:
@@ -30,13 +31,20 @@ def main():
         programmer = tinyfpgaa.JtagCustomProgrammer(jtag)
 
         if not args.q:
-            print("Parsing JEDEC file...")
-        jedec_file = tinyfpgaa.JedecFile(open(args.jed, 'r'))
+            if args.b:
+                print("Parsing bitstream file...")
+            else:
+                print("Parsing JEDEC file...")
+
+        if args.b:
+            input_file = tinyfpgaa.BitstreamFile(open(args.jed, 'rb'))
+        else:
+            input_file = tinyfpgaa.JedecFile(open(args.jed, 'r'))
 
         try:
             if not args.q:
                 print("Programming TinyFPGA A on {}...".format(a_port))
-            programmer.program(jedec_file)
+            programmer.program(input_file)
         except:
             print("Programming Failed!")
             traceback.print_exc()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+import setuptools
+
+setuptools.setup(
+    name="tinyfpgaa",
+    version="0.9.0",
+    author="William D. Jones",
+    author_email="thor0505@comcast.net",
+    description="A small example package",
+    url="https://github.com/tinyfpga/TinyFPGA-A-Programmer",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    packages=["tinyfpgaa"],
+    package_dir={"tinyfpgaa": "python"},
+    entry_points={
+        "console_scripts": ["tinyproga=tinyfpgaa.tinyproga:main"],
+    },
+    python_requires=">=3.7",
+)


### PR DESCRIPTION
This PR adds support for parsing Lattice bitstream files directly. To use you add the `-b` option to the command line invocation of the programmer. The bitstream parser will check to ensure we are writing a compressed bitstream and will not write if it detects an uncompressed bitstream.

Feature row and bits are currently [hardcoded](https://github.com/tinyfpga/TinyFPGA-A-Programmer/pull/3/files#diff-3d63c11d57eaa36ea5d790da1aaf57c9R1207-R1208) to default values I saw in JEDEC files. I'm not sure yet where they are kept in the bitstream (if at all!).

You should probably look at the `py3` branch and merge that before this PR.